### PR TITLE
making the language consistent with the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To initialize the wrapper use the following snippet, substituting in your `api k
 
 ```
 var NeverBounce = require('neverbounce')({
-    apiKey: API_KEY,
+    apiKey: API_USER_NAME,
     apiSecret: API_SECRET_KEY
 });
 ```


### PR DESCRIPTION
The API key page gives us a API user name, and not an API key. Support told me they are the same so here's a PR to make it less confusing for future travelers 