### PR TITLE
Fixing package.json main path to src/ instead of lib/

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neverbounce",
   "version": "4.1.2",
   "description": "An API wrapper for the NeverBounce API",
-  "main": "lib/NeverBounce.js",
+  "main": "src/NeverBounce.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/NeverBounce/NeverBounceApi-NodeJS"


### PR DESCRIPTION
When I tried to import the neverbounce package, it failed to load the module correctly.

`package.json` references the nonexistent `lib/Neverbounce.js` as `main`. This PR changes the path to `src/NeverBounce.js` to fix this.

This problem seems to be consistent with README.md as well, which hides the problem by using a relative file path:

```
const NeverBounce = require('../src/NeverBounce.js');
```

You should be able to use this package as follows after installing the package:

```
const NeverBounce = require("neverbounce");
```

This PR only fixes the core problem of referencing the file correctly.