### PR TITLE
#NB-296 Removed EOL NodeJS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: node_js
 node_js:
-  - '6'
-  - '7'
   - '8'
   - '9'
   - '10'
   - '11'
+  - '12'
+  - '13'
   - node
   - lts/*
-script: 
+script:
   - npm run lint
   - npm test
 notifications:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neverbounce",
-  "version": "4.2.0",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "neverbounce",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "An API wrapper for the NeverBounce API",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8.0"
   },
   "main": "src/NeverBounce.js",
   "repository": {


### PR DESCRIPTION
[#NB-296 Update NodeJS wrapper to drop EOL versions](https://discoverorg.atlassian.net/browse/NB-296)
Removed support for 6 and 7 versions of Node
Added 12 and 13 versions for Travis tests